### PR TITLE
Fix function type, fixing clang compilation

### DIFF
--- a/eventfd/_eventfd.c
+++ b/eventfd/_eventfd.c
@@ -2,7 +2,7 @@
 #include <sys/eventfd.h>
 
 
-static PyObject * _eventfd(PyObject *self) {
+static PyObject * _eventfd(PyObject *self, PyObject *args) {
     int result;
 
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
```
clang-16 -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -ffile-prefix-map=/build/python3.9-RNBry6/python3.9-3.9.2=. -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -march=native -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.9 -c eventfd/_eventfd.c -o /home/mujin/mujin/jhbuildappcontroller/build/eventfd/temp.linux-x86_64-3.9/eventfd/_eventfd.o
eventfd/_eventfd.c:21:18: error: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyObject *(PyObject *)' (aka 'struct _object *(struct _object *)') [-Wincompatible-function-pointer-types]
     {"eventfd", _eventfd, METH_NOARGS, "return new eventfd"},
```